### PR TITLE
Get transactions in a completed or rejected state

### DIFF
--- a/app_dir/wallet_transactions/url_batch_transaction_urls.py
+++ b/app_dir/wallet_transactions/url_batch_transaction_urls.py
@@ -5,6 +5,9 @@ urlpatterns = [
     url(r'^(?P<batch_trid>[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[1345][a-fA-F0-9]{3}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12})$',
         GetBatchTransaction.as_view(),
         name='get_batch_transaction'),
+    url(r'^(?P<batch_trid>[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[1345][a-fA-F0-9]{3}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12})/(?P<state>[\w\-]+)$',
+        GetBatchTransaction.as_view(),
+        name='get_batch_transaction_by_state'),
     url(r'$', BatchTransactions.as_view(), name='batchtransactions'),
 ]
 

--- a/app_dir/wallet_transactions/views.py
+++ b/app_dir/wallet_transactions/views.py
@@ -368,10 +368,9 @@ class GetBatchTransaction(APIView):
             )
 
         try:
-            print(q_objects)
             batch_transactions = BatchTransactionLookup.objects.filter(
-                **kwargs
-            ).filter(q_objects)
+                q_objects, **kwargs
+            ).filter()
 
             if not batch_transactions:
                 logger.info(

--- a/app_dir/wallet_transactions/views.py
+++ b/app_dir/wallet_transactions/views.py
@@ -370,7 +370,7 @@ class GetBatchTransaction(APIView):
         try:
             batch_transactions = BatchTransactionLookup.objects.filter(
                 q_objects, **kwargs
-            ).filter()
+            )
 
             if not batch_transactions:
                 logger.info(

--- a/app_dir/wallet_transactions/views.py
+++ b/app_dir/wallet_transactions/views.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError
 from django.forms import model_to_dict
 from django.http import Http404
+from django.db.models import Q
 from rest_framework import generics, status
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
@@ -299,7 +300,7 @@ class GetBatchTransaction(APIView):
     This API allows retrieving a bulk transaction given an ID
     """
 
-    def get(self, request, batch_trid=None):
+    def get(self, request, batch_trid=None, state=None):
         if not batch_trid:
             logger.info(
                     "get_transaction_invalid_uuid",
@@ -313,6 +314,43 @@ class GetBatchTransaction(APIView):
                     key="batch_transaction_reference",
                     status=status.HTTP_400_BAD_REQUEST
             )
+
+        kwargs = {}
+        q_objects = Q()
+        if batch_trid:
+            kwargs['batch_transaction__batch_trid'] = batch_trid
+
+        # todo-steve: feels a bit inelegant - look into refining this Q query
+        if state:
+            if state in ["completions", "rejections"]:
+                if state == "rejections":
+                    kwargs['transaction__state'] = \
+                        Transaction.TRANSACTION_STATES[3][0]
+
+                if state == "completions":
+                    q_objects.add(
+                        Q(transaction__state__exact=
+                          Transaction.TRANSACTION_STATES[2][0]),
+                        Q.OR
+                    )
+                    q_objects.add(
+                        Q(transaction__state__exact=
+                          Transaction.TRANSACTION_STATES[4][0]),
+                        Q.OR
+                    )
+            else:
+                logger.info(
+                    "get_transaction_invalid_state",
+                    status=status.HTTP_400_BAD_REQUEST,
+                    state=state,
+                    key="state"
+                )
+
+                return send_error_response(
+                    message="Invalid State",
+                    key="batch_transaction_reference",
+                    status=status.HTTP_400_BAD_REQUEST
+                )
 
         date = request.META.get("HTTP_DATE")
         if not date and not settings.DEBUG:
@@ -330,9 +368,10 @@ class GetBatchTransaction(APIView):
             )
 
         try:
+            print(q_objects)
             batch_transactions = BatchTransactionLookup.objects.filter(
-                    batch_transaction__batch_trid=batch_trid
-            )
+                **kwargs
+            ).filter(q_objects)
 
             if not batch_transactions:
                 logger.info(


### PR DESCRIPTION
This covers:

- https://github.com/kyrelos/vitelco-mobile-money-wallet/issues/40
- https://github.com/kyrelos/vitelco-mobile-money-wallet/issues/41

Transactions that are `completed` or `reversed` are **completions**, while `failed` are **rejections**